### PR TITLE
Api add with tutor subjects

### DIFF
--- a/backend/src/GTPSchedulerApplication.API/Controllers/TutorProfile.cs
+++ b/backend/src/GTPSchedulerApplication.API/Controllers/TutorProfile.cs
@@ -1,0 +1,21 @@
+﻿using AutoMapper;
+using GTPSchedulerApplication.Core.Entities;
+namespace GTPSchedulerApplication.API.Controllers
+{
+    public class TutorProfile : Profile
+    {
+        public TutorProfile()
+        {
+            // Entity → DTO
+            CreateMap<Tutor, TutorDto>();
+            CreateMap<TutorSubject, TutorSubjectDto>()
+                .ForMember(dest => dest.SubjectName, opt => opt.MapFrom(src => src.Subject.Name));
+            CreateMap<TutorAvailability, TutorAvailabilityDto>();
+
+            // DTO → Entity
+            CreateMap<CreateTutorDto, Tutor>();
+            CreateMap<CreateTutorSubjectDto, TutorSubject>();
+            CreateMap<CreateTutorAvailabilityDto, TutorAvailability>();
+        }
+    }
+}

--- a/backend/src/GTPSchedulerApplication.API/Controllers/TutorProfile.cs
+++ b/backend/src/GTPSchedulerApplication.API/Controllers/TutorProfile.cs
@@ -8,8 +8,7 @@ namespace GTPSchedulerApplication.API.Controllers
         {
             // Entity → DTO
             CreateMap<Tutor, TutorDto>();
-            CreateMap<TutorSubject, TutorSubjectDto>()
-                .ForMember(dest => dest.SubjectName, opt => opt.MapFrom(src => src.Subject.Name));
+            CreateMap<TutorSubject, TutorSubjectDto>();
             CreateMap<TutorAvailability, TutorAvailabilityDto>();
 
             // DTO → Entity

--- a/backend/src/GTPSchedulerApplication.API/Controllers/TutorsController.cs
+++ b/backend/src/GTPSchedulerApplication.API/Controllers/TutorsController.cs
@@ -17,18 +17,8 @@ public class TutorsController : ControllerBase
         _mapper = mapper;
     }
 
-    [HttpGet]
-    public async Task<ActionResult<List<Tutor>>> GetTutors()
-    {
-        return await _context.Tutors
-            .Include(t => t.TutorSubjects)
-                .ThenInclude(ts => ts.Subject)
-            .Include(t => t.Availability)
-            .ToListAsync();
-    }
-
     [HttpPost]
-    public async Task<ActionResult<Tutor>> CreateTutor(CreateTutorDto dto)
+    public async Task<ActionResult<TutorDto>> CreateTutor(CreateTutorDto dto)
     {
         var tutor = _mapper.Map<Tutor>(dto);
 
@@ -47,8 +37,20 @@ public class TutorsController : ControllerBase
         return CreatedAtAction(nameof(GetTutor), new { id = tutor.Id }, tutorDto);
     }
 
+    [HttpGet]
+    public async Task<ActionResult<List<TutorDto>>> GetTutors()
+    {
+        var tutors = await _context.Tutors
+            .Include(t => t.TutorSubjects)
+                .ThenInclude(ts => ts.Subject)
+            .Include(t => t.Availability)
+            .ToListAsync();
+
+        return _mapper.Map<List<TutorDto>>(tutors);
+    }
+
     [HttpGet("{id}")]
-    public async Task<ActionResult<Tutor>> GetTutor(int id)
+    public async Task<ActionResult<TutorDto>> GetTutor(int id)
     {
         var tutor = await _context.Tutors
             .Include(t => t.TutorSubjects)
@@ -56,7 +58,7 @@ public class TutorsController : ControllerBase
             .Include(t => t.Availability)
             .FirstOrDefaultAsync(t => t.Id == id);
 
-        return tutor == null ? NotFound() : tutor;
+        return tutor == null ? NotFound() : _mapper.Map<TutorDto>(tutor);
     }
 
     [HttpDelete("{id}")]
@@ -75,8 +77,19 @@ public class TutorsController : ControllerBase
         }
     }
 }
+
+// input DTOs (createTutor)
+public record CreateTutorSubjectDto(int SubjectId, int ProficiencyLevel, string? SubjectName);
+public record CreateTutorAvailabilityDto(DayOfWeek DayOfWeek, TimeOnly StartTime, TimeOnly EndTime);
+public record CreateTutorDto(
+    string Name, 
+    string Email, 
+    List<CreateTutorSubjectDto> TutorSubjects, 
+    List<CreateTutorAvailabilityDto> Availability
+    );
+
 // output DTO for API (GetTutor/after creation)
-public record TutorSubjectDto(int SubjectId, string SubjectName, int ProficiencyLevel);
+public record TutorSubjectDto(int SubjectId, int ProficiencyLevel, string? SubjectName);
 public record TutorAvailabilityDto(DayOfWeek DayOfWeek, TimeOnly StartTime, TimeOnly EndTime);
 public record TutorDto(
     int Id, 
@@ -88,15 +101,6 @@ public record TutorDto(
     );
 
 
-// input DTOs (createTutor)
-public record CreateTutorSubjectDto(int SubjectId, string SubjectName, int ProficiencyLevel);
-public record CreateTutorAvailabilityDto(DayOfWeek DayOfWeek, TimeOnly StartTime, TimeOnly EndTime);
-public record CreateTutorDto(
-    string Name, 
-    string Email, 
-    List<CreateTutorSubjectDto> TutorSubjects, 
-    List<CreateTutorAvailabilityDto> Availability
-    );
 
 
 

--- a/backend/src/GTPSchedulerApplication.API/GTPSchedulerApplication.API.csproj
+++ b/backend/src/GTPSchedulerApplication.API/GTPSchedulerApplication.API.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -17,6 +18,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="9.0.4" />
+    <PackageReference Include="xunit" Version="2.9.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/backend/src/GTPSchedulerApplication.API/Program.cs
+++ b/backend/src/GTPSchedulerApplication.API/Program.cs
@@ -1,3 +1,4 @@
+using GTPSchedulerApplication.API.Controllers;
 using GTPSchedulerApplication.Infrastructure.Data;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.EntityFrameworkCore;
@@ -11,6 +12,9 @@ builder.Services.AddOpenApi(); // to facilitate documentation
 // Add db context 
 builder.Services.AddDbContext<GTPSchedulerApplicationDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
+
+// Add automapper for entities
+builder.Services.AddAutoMapper(typeof(TutorProfile));
 
 // Add CORS for frontend 
 builder.Services.AddCors(options =>

--- a/backend/src/GTPSchedulerApplication.API/UnitTests/TutorMappingTests.cs
+++ b/backend/src/GTPSchedulerApplication.API/UnitTests/TutorMappingTests.cs
@@ -13,7 +13,7 @@ namespace GTPSchedulerApplication.API.UnitTests
         {
             var config = new MapperConfiguration(cfg =>
             {
-                cfg.AddProfile<TutorProfile>(); // Your AutoMapper profile
+                cfg.AddProfile<TutorProfile>(); // AutoMapper profile
             });
 
             config.AssertConfigurationIsValid(); // Throws if any mapping is misconfigured
@@ -28,7 +28,7 @@ namespace GTPSchedulerApplication.API.UnitTests
                 "viviana@example.com",
                 new List<CreateTutorSubjectDto>
                 {
-                    new(3, 2, "Computer Science")
+                    new("CS", 2, "Computer Science")
                 },
                 new List<CreateTutorAvailabilityDto>
                 {

--- a/backend/src/GTPSchedulerApplication.API/UnitTests/TutorMappingTests.cs
+++ b/backend/src/GTPSchedulerApplication.API/UnitTests/TutorMappingTests.cs
@@ -28,7 +28,7 @@ namespace GTPSchedulerApplication.API.UnitTests
                 "viviana@example.com",
                 new List<CreateTutorSubjectDto>
                 {
-                    new(1, "Computer Science", 2)
+                    new(3, 2, "Computer Science")
                 },
                 new List<CreateTutorAvailabilityDto>
                 {
@@ -42,7 +42,7 @@ namespace GTPSchedulerApplication.API.UnitTests
             Assert.Equal(dto.Email, tutor.Email);
             Assert.Single(tutor.TutorSubjects);
             Assert.Single(tutor.Availability);
-            Assert.Equal(1, tutor.TutorSubjects[0].SubjectId);
+            Assert.Equal(3, tutor.TutorSubjects[0].SubjectId);
             Assert.Equal(2, tutor.TutorSubjects[0].ProficiencyLevel);
         }
     }

--- a/backend/src/GTPSchedulerApplication.API/UnitTests/TutorMappingTests.cs
+++ b/backend/src/GTPSchedulerApplication.API/UnitTests/TutorMappingTests.cs
@@ -1,0 +1,49 @@
+﻿using AutoMapper;
+using GTPSchedulerApplication.API.Controllers;
+using GTPSchedulerApplication.Core.Entities;
+using Xunit; 
+
+namespace GTPSchedulerApplication.API.UnitTests
+{
+    public class TutorMappingTests
+    {
+        private readonly IMapper _mapper;
+
+        public TutorMappingTests()
+        {
+            var config = new MapperConfiguration(cfg =>
+            {
+                cfg.AddProfile<TutorProfile>(); // Your AutoMapper profile
+            });
+
+            config.AssertConfigurationIsValid(); // Throws if any mapping is misconfigured
+            _mapper = config.CreateMapper();
+        }
+
+        [Fact]
+        public void Should_Map_CreateTutorDto_To_Tutor()
+        {
+            var dto = new CreateTutorDto(
+                "Viviana Rosas",
+                "viviana@example.com",
+                new List<CreateTutorSubjectDto>
+                {
+                    new(1, "Computer Science", 2)
+                },
+                new List<CreateTutorAvailabilityDto>
+                {
+                    new(DayOfWeek.Monday, new TimeOnly(9, 0, 0), new TimeOnly(12, 0, 0))
+                }
+            );
+
+            var tutor = _mapper.Map<Tutor>(dto);
+
+            Assert.Equal(dto.Name, tutor.Name);
+            Assert.Equal(dto.Email, tutor.Email);
+            Assert.Single(tutor.TutorSubjects);
+            Assert.Single(tutor.Availability);
+            Assert.Equal(1, tutor.TutorSubjects[0].SubjectId);
+            Assert.Equal(2, tutor.TutorSubjects[0].ProficiencyLevel);
+        }
+    }
+}

--- a/backend/src/GTPSchedulerApplication.Core/Entities/Tutor.cs
+++ b/backend/src/GTPSchedulerApplication.Core/Entities/Tutor.cs
@@ -1,9 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace GTPSchedulerApplication.Core.Entities
 {
     public class Tutor { 

--- a/backend/src/GTPSchedulerApplication.Core/Entities/TutorSubject.cs
+++ b/backend/src/GTPSchedulerApplication.Core/Entities/TutorSubject.cs
@@ -8,8 +8,8 @@ namespace GTPSchedulerApplication.Core.Entities
 {
     public class TutorSubject
     {
-        public int TutorId { get; set; }
-        public int SubjectId { get; set; }
+        public int TutorId { get; set; } // what tutor is assigned to it
+        public int SubjectId { get; set; } 
         public int ProficiencyLevel { get; set; } // 0-2 scale
 
         public Tutor Tutor { get; set; } = null!;

--- a/backend/src/GTPSchedulerApplication.Core/Entities/TutorSubject.cs
+++ b/backend/src/GTPSchedulerApplication.Core/Entities/TutorSubject.cs
@@ -10,7 +10,7 @@ namespace GTPSchedulerApplication.Core.Entities
     {
         public int TutorId { get; set; }
         public int SubjectId { get; set; }
-        public int ProficiencyLevel { get; set; } // 1-5 scale
+        public int ProficiencyLevel { get; set; } // 0-2 scale
 
         public Tutor Tutor { get; set; } = null!;
         public Subject Subject { get; set; } = null!;

--- a/frontend/src/app/tutors/page.tsx
+++ b/frontend/src/app/tutors/page.tsx
@@ -35,10 +35,10 @@ export default function TutorsPage() {
 
   // getting data from tutorAdditionForm
   const [tutorInfo, setTutorInfo] =
-    useState<Omit<Tutor, "id" | "tutorSubjects" | "availability">>();
+    useState<Omit<Tutor, "id" | "availability">>();
 
   const handleTutorCreation = async (
-    data: Omit<Tutor, "id" | "tutorSubjects" | "availability">
+    data: Omit<Tutor, "id" | "availability">
   ) => {
     try {
       setTutorInfo(data);

--- a/frontend/src/app/tutors/page.tsx
+++ b/frontend/src/app/tutors/page.tsx
@@ -126,7 +126,7 @@ export default function TutorsPage() {
                             key={ts.subjectId}
                             className="bg-blue-50 text-blue-700 px-2 py-0.5 rounded text-xs"
                           >
-                            {ts.subject.name}
+                            {ts.subjectName} {/* used to be ts.subject.name*/}
                           </span>
                         )) || (
                           <span className="text-gray-400">No subjects</span>

--- a/frontend/src/components/TutorAdditionForm.tsx
+++ b/frontend/src/components/TutorAdditionForm.tsx
@@ -1,17 +1,12 @@
-import Form from "next/form";
-import React, { useEffect, useState } from "react";
-import Availability from "@/components/Availability";
-import { tutorService } from "@/services/tutorService";
-// How to get selected courses for form submission
+import { useState, ChangeEvent, FormEvent } from "react";
 
 export default function TutorAdditionForm({ onSubmit }: { onSubmit: any }) {
-  const [name, setName] = React.useState("");
-  const [email, setEmail] = React.useState("");
-  const [subjects, setSubjects] = React.useState<string[]>([]);
-  const [proficiency, setProficiency] = React.useState("0: No experience");
-  // TODO: Add state for availability if needed
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [subjects, setSubjects] = useState<string[]>([]);
+  const [proficiency, setProficiency] = useState("0: No experience");
 
-  const handleSubjectsChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+  const handleSubjectsChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const selected = Array.from(
       e.target.selectedOptions,
       (option) => option.value
@@ -24,14 +19,13 @@ export default function TutorAdditionForm({ onSubmit }: { onSubmit: any }) {
     proficiencyLevel: parseInt(proficiency[0]),
   }));
 
-  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const tutorData = {
       name,
       email,
       isActive: true,
       tutorSubjects,
-      availability: [], // TODO: collect from Availability component
     };
     onSubmit(tutorData);
   };

--- a/frontend/src/components/TutorAdditionForm.tsx
+++ b/frontend/src/components/TutorAdditionForm.tsx
@@ -19,18 +19,18 @@ export default function TutorAdditionForm({ onSubmit }: { onSubmit: any }) {
     setSubjects(selected);
   };
 
+  const tutorSubjects = subjects.map((code) => ({
+    subjectCode: code,
+    proficiencyLevel: parseInt(proficiency[0]),
+  }));
+
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     const tutorData = {
       name,
       email,
       isActive: true,
-      tutorSubjects: subjects.map((subject) => ({
-        subject: { name: subject, code: subject, id: 0 },
-        proficiencyLevel: parseInt(proficiency[0]),
-        tutorId: 0,
-        subjectId: 0,
-      })),
+      tutorSubjects,
       availability: [], // TODO: collect from Availability component
     };
     onSubmit(tutorData);
@@ -93,9 +93,9 @@ export default function TutorAdditionForm({ onSubmit }: { onSubmit: any }) {
               value={subjects}
               onChange={handleSubjectsChange}
             >
-              <option>Computer Science</option>
-              <option>Physics</option>
-              <option>Biology</option>
+              <option value="CS">Computer Science</option>
+              <option value="PHY">Physics</option>
+              <option value="BIO">Biology</option>
             </select>
           </div>
           <div className="w-full md:w-1/2 px-3 mb-6 md:mb-0">
@@ -115,28 +115,6 @@ export default function TutorAdditionForm({ onSubmit }: { onSubmit: any }) {
               <option>1: Less than a year</option>
               <option>2: Can teach</option>
             </select>
-            <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
-              <svg
-                className="fill-current h-4 w-4"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-              >
-                <path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" />
-              </svg>
-            </div>
-          </div>
-        </div>
-
-        {/* day availability */}
-        <div className="flex flex-wrap -mx-3 mb-6">
-          <div className="w-full px-3">
-            <label
-              className="block uppercase tracking-wide text-gray-700 text-xs font-bold mb-2"
-              htmlFor="availability"
-            >
-              Availability
-            </label>
-            <Availability />
             <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
               <svg
                 className="fill-current h-4 w-4"

--- a/frontend/src/services/tutorService.ts
+++ b/frontend/src/services/tutorService.ts
@@ -1,28 +1,30 @@
-import { backendApi } from './api';
-import { Tutor } from '../types';
+import { backendApi } from "./api";
+import { Tutor } from "../types";
 
 export const tutorService = {
-    getTutors: async (): Promise<Tutor[]> => {
-        const response = await backendApi.get('/tutors');
-        return response.data;
-    },
+  getTutors: async (): Promise<Tutor[]> => {
+    const response = await backendApi.get("/tutors");
+    return response.data;
+  },
 
-    getTutor: async (id: number): Promise<Tutor> => {
-        const response = await backendApi.get(`/tutors/${id}`);
-        return response.data;
-    },
+  getTutor: async (id: number): Promise<Tutor> => {
+    const response = await backendApi.get(`/tutors/${id}`);
+    return response.data;
+  },
 
-    createTutor: async (tutor: Omit<Tutor, 'id' | 'tutorSubjects' | 'availability'>): Promise<Tutor> => {
-        const response = await backendApi.post('/tutors', tutor);
-        return response.data;
-    },
+  createTutor: async (
+    tutor: Omit<Tutor, "id" | "availability">
+  ): Promise<Tutor> => {
+    const response = await backendApi.post("/tutors", tutor);
+    return response.data;
+  },
 
-    updateTutor: async (id: number, tutor: Partial<Tutor>): Promise<Tutor> => {
-        const response = await backendApi.put(`/tutors/${id}`, tutor);
-        return response.data;
-    },
+  updateTutor: async (id: number, tutor: Partial<Tutor>): Promise<Tutor> => {
+    const response = await backendApi.put(`/tutors/${id}`, tutor);
+    return response.data;
+  },
 
-    deleteTutor: async (id: number): Promise<void> => {
-        await backendApi.delete(`/tutors/${id}`);
-    }
+  deleteTutor: async (id: number): Promise<void> => {
+    await backendApi.delete(`/tutors/${id}`);
+  },
 };

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -12,12 +12,12 @@ export interface TutorSubject {
   subjectId: number;
   proficiencyLevel: number; // 0 - 2 (none, >1 year, <=1 year)
   subjectName: string; // todo: cop out, determine if need to change
-  subject: Subject;
+  // subject: Subject;
 }
 
 export interface Subject {
-  id: number;
-  name: string;
+  // id: number; should get this from backend
+  // name: string; // only need visual name on frontend, no need to interface
   code: string;
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -11,6 +11,7 @@ export interface TutorSubject {
   tutorId: number;
   subjectId: number;
   proficiencyLevel: number; // 0 - 2 (none, >1 year, <=1 year)
+  subjectName: string; // todo: cop out, determine if need to change
   subject: Subject;
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -11,13 +11,10 @@ export interface TutorSubject {
   tutorId: number;
   subjectId: number;
   proficiencyLevel: number; // 0 - 2 (none, >1 year, <=1 year)
-  subjectName: string; // todo: cop out, determine if need to change
-  // subject: Subject;
+  subjectName: string;
 }
 
 export interface Subject {
-  // id: number; should get this from backend
-  // name: string; // only need visual name on frontend, no need to interface
   code: string;
 }
 


### PR DESCRIPTION
Overall: 
* Can add manually on backend and see on front-end
* Can add from front-end to back-end :)

Nitty gritty: 
* Removed Subject from TutorSubject FE interface because backend returns subjectName in API response
* Removed fields from Subject FE interface because "code" gets the subjectId and subjectName from backend
* Removed availability from tutor addition form so it's not required for tutor creation

<img width="740" height="664" alt="image" src="https://github.com/user-attachments/assets/51bf35e2-58a2-4385-a3e0-724b9236582b" />
